### PR TITLE
Trigger offset added

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -40,6 +40,12 @@
 @property (nonatomic) CGFloat infiniteScrollIndicatorMargin;
 
 /**
+ *  Sets the offset between the real end of the scroll view content and the scroll position, so the handler can be triggered before reaching end.
+ *  Defaults to 0.0;
+ */
+@property (nonatomic) CGFloat infiniteScrollTriggerOffset;
+
+/**
  *  Setup infinite scroll handler
  *
  *  @param handler a handler block

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -40,6 +40,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 static const void* kPBInfiniteScrollInitKey = &kPBInfiniteScrollInitKey;
 static const void* kPBInfiniteScrollExtraBottomInsetKey = &kPBInfiniteScrollExtraBottomInsetKey;
 static const void* kPBInfiniteScrollIndicatorMarginKey = &kPBInfiniteScrollIndicatorMarginKey;
+static const void* kPBInfiniteScrollTriggerOffsetKey = &kPBInfiniteScrollTriggerOffsetKey;
 
 // Infinite scroll states
 typedef NS_ENUM(NSInteger, PBInfiniteScrollState) {
@@ -155,6 +156,19 @@ CGFloat pb_infiniteScrollExtraBottomInset;
     }
     // Default row height minus activity indicator height
     return 11;
+}
+
+- (void)setInfiniteScrollTriggerOffset:(CGFloat)infiniteScrollTriggerOffset {
+    objc_setAssociatedObject(self, kPBInfiniteScrollTriggerOffsetKey, @(infiniteScrollTriggerOffset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (CGFloat)infiniteScrollTriggerOffset {
+    NSNumber* offset = objc_getAssociatedObject(self, kPBInfiniteScrollTriggerOffsetKey);
+    if(offset) {
+        return offset.floatValue;
+    }
+
+    return 0;
 }
 
 #pragma mark - Deprecated methods
@@ -372,7 +386,7 @@ CGFloat pb_infiniteScrollExtraBottomInset;
     CGFloat contentHeight = [self pb_adjustedHeightFromContentSize:self.contentSize];
     
     // The lower bound when infinite scroll should kick in
-    CGFloat actionOffset = contentHeight - self.bounds.size.height + self.contentInset.bottom;
+    CGFloat actionOffset = contentHeight - self.bounds.size.height + self.contentInset.bottom - self.infiniteScrollTriggerOffset;
     
     // Disable infinite scroll when scroll view is empty
     // Default UITableView reports height = 1 on empty tables

--- a/InfiniteScrollViewDemo/TableViewController.m
+++ b/InfiniteScrollViewDemo/TableViewController.m
@@ -54,6 +54,9 @@ static NSString* const kJSONNumPagesKey = @"nbPages";
     // Set custom indicator
     self.tableView.infiniteScrollIndicatorView = indicator;
     
+    // Set custom trigger offset
+    self.tableView.infiniteScrollTriggerOffset = 500.0;
+    
     // Add infinite scroll handler
     [self.tableView addInfiniteScrollWithHandler:^(UIScrollView* scrollView) {
         [weakSelf loadRemoteDataWithDelay:YES completion:^{

--- a/UIScrollView-InfiniteScroll.podspec
+++ b/UIScrollView-InfiniteScroll.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'UIScrollView-InfiniteScroll'
-  s.version  = '0.6.0'
+  s.version  = '0.7.0'
   s.license  = 'MIT'
   s.summary  = 'UIScrollView infinite scroll category.'
   s.homepage = 'https://github.com/pronebird/UIScrollView-InfiniteScroll'
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     'Andrej Mihajlov' => 'and@codeispoetry.ru'
   }
   s.source   = {
-    :git => 'https://github.com/pronebird/UIScrollView-InfiniteScroll.git',
+    :git => 'https://github.com/GorkaMM/UIScrollView-InfiniteScroll.git',
     :tag => s.version.to_s
   }
   s.source_files = 'Classes/*.{h,m}'


### PR DESCRIPTION
I added a property to set an offset between the real end of the scroll view content and the scroll position, so the handler can be triggered before reaching end. I also updated the example.