### PR TITLE
Fix scrollview interface pollution

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -27,7 +27,7 @@
  *
  *  Infinite scroll will call implemented methods during user interaction.
  */
-@property (nonatomic) UIView* infiniteScrollIndicatorView;
+@property (nonatomic) UIView *infiniteScrollIndicatorView;
 
 /**
  *  Vertical margin around indicator view (Default: 11)

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -35,10 +35,10 @@ static const NSTimeInterval kPBInfiniteScrollAnimationDuration = 0.35;
 // Keys for values in associated dictionary
 static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 
-//
-// Infinite scroll state.
-// @private
-//
+/**
+ *  Infinite scroll state class.
+ *  @private
+ */
 @interface _PBInfiniteScrollState : NSObject
 
 /**
@@ -99,9 +99,15 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 
 @end
 
-// Private category on UIScrollView to define dynamic properties
+
+/**
+ *  Private category on UIScrollView to define dynamic properties.
+ */
 @interface UIScrollView ()
 
+/**
+ *  Infinite scroll state.
+ */
 @property (nonatomic, readonly, getter=pb_infiniteScrollState) _PBInfiniteScrollState *pb_infiniteScrollState;
 
 @end

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -111,7 +111,6 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 #pragma mark - Public methods
 
 - (void)addInfiniteScrollWithHandler:(void(^)(id scrollView))handler {
-    // make sure state exists
     _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
     
     // Save handler block
@@ -196,7 +195,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 
 - (_PBInfiniteScrollState *)pb_infiniteScrollState {
     _PBInfiniteScrollState *state = objc_getAssociatedObject(self, kPBInfiniteScrollStateKey);
-    
+
     if(!state) {
         state = [_PBInfiniteScrollState new];
         
@@ -288,6 +287,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     if(state.infiniteScrollHandler) {
         state.infiniteScrollHandler(self);
     }
+    
     TRACE(@"Call handler.");
 }
 

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -33,7 +33,7 @@ static void PBSwizzleMethod(Class c, SEL original, SEL alternate) {
 static const NSTimeInterval kPBInfiniteScrollAnimationDuration = 0.35;
 
 // Keys for values in associated dictionary
-static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
+static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 
 /**
  *  Infinite scroll state class.
@@ -302,8 +302,8 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  *
  *  @return indicator view.
  */
-- (UIView*)pb_getOrCreateActivityIndicatorView {
-    UIView* activityIndicator = self.infiniteScrollIndicatorView;
+- (UIView *)pb_getOrCreateActivityIndicatorView {
+    UIView *activityIndicator = self.infiniteScrollIndicatorView;
     
     if(!activityIndicator) {
         activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:self.infiniteScrollIndicatorStyle];
@@ -324,7 +324,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  *  @return CGFloat
  */
 - (CGFloat)pb_infiniteIndicatorRowHeight {
-    UIView* activityIndicator = [self pb_getOrCreateActivityIndicatorView];
+    UIView *activityIndicator = [self pb_getOrCreateActivityIndicatorView];
     CGFloat indicatorHeight = CGRectGetHeight(activityIndicator.bounds);
     
     return indicatorHeight + self.infiniteScrollIndicatorMargin * 2;
@@ -336,7 +336,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  *  @param contentSize content size.
  */
 - (void)pb_positionInfiniteScrollIndicatorWithContentSize:(CGSize)contentSize {
-    UIView* activityIndicator = [self pb_getOrCreateActivityIndicatorView];
+    UIView *activityIndicator = [self pb_getOrCreateActivityIndicatorView];
     CGFloat contentHeight = [self pb_clampContentSizeToFitVisibleBounds:contentSize];
     CGFloat indicatorRowHeight = [self pb_infiniteIndicatorRowHeight];
     CGPoint center = CGPointMake(contentSize.width * 0.5, contentHeight + indicatorRowHeight * 0.5);
@@ -351,7 +351,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  */
 - (void)pb_startAnimatingInfiniteScroll {
     _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
-    UIView* activityIndicator = [self pb_getOrCreateActivityIndicatorView];
+    UIView *activityIndicator = [self pb_getOrCreateActivityIndicatorView];
     
     // Layout indicator view
     [self pb_positionInfiniteScrollIndicatorWithContentSize:self.contentSize];
@@ -404,7 +404,7 @@ static const void* kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  */
 - (void)pb_stopAnimatingInfiniteScrollWithCompletion:(void(^)(id scrollView))handler {
     _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
-    UIView* activityIndicator = self.infiniteScrollIndicatorView;
+    UIView *activityIndicator = self.infiniteScrollIndicatorView;
     UIEdgeInsets contentInset = self.contentInset;
     
     // Remove row height inset


### PR DESCRIPTION
We have excessive amount of dynamic properties, it gets painful to maintain them and (even though private) getters and setters pollute UIScrollView interface. I grouped all props into a single state class.