### PR TITLE
Block to check if infinite scroll should show

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -49,6 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addInfiniteScrollWithHandler:(void(^)(UIScrollView *scrollView))handler;
 
 /**
+ *  Set a handler to be called to check if the infinite scroll should be shown
+ *
+ *  @param handler a handler block
+ */
+-(void)setShouldShowInfiniteScrollHandler:(BOOL(^)(UIScrollView *scrollView))handler;
+
+/**
  *  Unregister infinite scroll
  */
 - (void)removeInfiniteScroll;

--- a/InfiniteScrollViewDemo/TableViewController.m
+++ b/InfiniteScrollViewDemo/TableViewController.m
@@ -86,10 +86,12 @@ static NSString *const kJSONNumPagesKey = @"nbPages";
     }];
     
     //Uncomment this to provide conditionally prevent the infinite scroll from triggering
+    /*
     [self.tableView setShouldShowInfiniteScrollHandler:^BOOL(UIScrollView * _Nonnull scrollView) {
         //Only show up to 5 pages then prevent the infinite scroll
         return (self.currentPage < 5);
     }];
+     */
     
     // Load initial data
     [self fetchData:nil];

--- a/InfiniteScrollViewDemo/TableViewController.m
+++ b/InfiniteScrollViewDemo/TableViewController.m
@@ -85,6 +85,12 @@ static NSString *const kJSONNumPagesKey = @"nbPages";
         }];
     }];
     
+    //Uncomment this to provide conditionally prevent the infinite scroll from triggering
+    [self.tableView setShouldShowInfiniteScrollHandler:^BOOL(UIScrollView * _Nonnull scrollView) {
+        //Only show up to 5 pages then prevent the infinite scroll
+        return (self.currentPage < 5);
+    }];
+    
     // Load initial data
     [self fetchData:nil];
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,19 @@ Please see example implementation of indicator view:
 
 At the moment InfiniteScroll uses indicator's frame directly so make sure you size custom indicator view beforehand. Such views as `UIImageView` or `UIActivityIndicatorView` will automatically resize themselves so no need to setup frame for them.
 
+### Preventing Infinite Scroll from Triggering
+
+Sometimes you need to prevent the infinite scroll from continuing.  For example, if your search API has no more results, it does not make sense to keep making the requests or to show the spinner.
+
+Objective-C: 
+```objc
+//Provide a block to be called right before a infinite scroll event is triggered.  Return YES to allow or NO to prevent it from triggering.
+[self.tableView setShouldShowInfiniteScrollHandler:^BOOL(UIScrollView * _Nonnull scrollView) {
+    //Only show up to 5 pages then prevent the infinite scroll
+    return (self.currentPage < 5);
+}];
+```
+
 ### Contributors
 
 * Maxim Veksler [@maximveksler](https://github.com/maximveksler)<br/>


### PR DESCRIPTION
I needed the ability to prevent the infinite scroll from triggering in certain cases (search results exhausted, no more results, etc).

An additional block which expects a BOOL returned if the infinite scroll should be allowed has been implemented. 

Thanks for the great library! 