### PR TITLE
Add support to manually trigger infinite scroll

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -67,6 +67,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeInfiniteScroll;
 
 /**
+ *  Manually begin infinite scroll animations
+ *
+ *  This method provides identical behavior to user initiated scrolling.
+ *
+ *  @param forceScroll pass YES to scroll to indicator view
+ */
+- (void)beginInfiniteScroll:(BOOL)forceScroll;
+
+/**
  *  Finish infinite scroll animations
  *
  *  You must call this method from your infinite scroll handler to finish all

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -76,6 +76,12 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 @property (nonatomic) UIActivityIndicatorViewStyle indicatorStyle;
 
 /**
+ *  Flag used to return user back to top of scroll view 
+ *  when loading initial content
+ */
+@property (nonatomic) BOOL scrollToTopWhenFinished;
+
+/**
  *  Extra padding to push indicator view below view bounds.
  *  Used in case when content size is smaller than view bounds
  */
@@ -191,6 +197,10 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     state.initialized = NO;
 }
 
+- (void)beginInfiniteScroll:(BOOL)forceScroll {
+    [self pb_beginInfinitScrollIfNeeded:forceScroll];
+}
+
 - (void)finishInfiniteScroll {
     [self finishInfiniteScrollWithCompletion:nil];
 }
@@ -292,7 +302,7 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  */
 - (void)pb_handlePanGesture:(UITapGestureRecognizer *)gestureRecognizer {
     if(gestureRecognizer.state == UIGestureRecognizerStateEnded) {
-        [self pb_scrollToInfiniteIndicatorIfNeeded:YES];
+        [self pb_scrollToInfiniteIndicatorIfNeeded:YES force:NO];
     }
 }
 
@@ -335,6 +345,22 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     CGFloat minHeight = self.bounds.size.height - self.contentInset.top - [self pb_originalBottomInset];
 
     return MAX(contentSize.height, minHeight);
+}
+
+/**
+ *  Checks if UIScrollView is empty.
+ *
+ *  @return BOOL
+ */
+- (BOOL)pb_hasContent {
+    CGFloat constant = 0;
+    
+    // Default UITableView reports height = 1 on empty tables
+    if([self isKindOfClass:[UITableView class]]) {
+        constant = 1;
+    }
+    
+    return self.contentSize.height > constant;
 }
 
 /**
@@ -411,9 +437,33 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 }
 
 /**
+ *  Update infinite scroll indicator's position in view.
+ *
+ *  @param forceScroll force scroll to indicator view
+ */
+- (void)pb_beginInfinitScrollIfNeeded:(BOOL)forceScroll {
+    _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
+    
+    // already loading?
+    if(state.loading) {
+        return;
+    }
+    
+    TRACE(@"Action.");
+    
+    // Only show the infinite scroll if it is allowed
+    if([self pb_shouldShowInfiniteScroll]) {
+        [self pb_startAnimatingInfiniteScroll:forceScroll];
+        
+        // This will delay handler execution until scroll deceleration
+        [self performSelector:@selector(pb_callInfiniteScrollHandler) withObject:self afterDelay:0.1 inModes:@[ NSDefaultRunLoopMode ]];
+    }
+}
+
+/**
  *  Start animating infinite indicator
  */
-- (void)pb_startAnimatingInfiniteScroll {
+- (void)pb_startAnimatingInfiniteScroll:(BOOL)forceScroll {
     _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
     UIView *activityIndicator = [self pb_getOrCreateActivityIndicatorView];
     
@@ -451,10 +501,13 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     // Update infinite scroll state
     state.loading = YES;
     
+    // Scroll to top if scroll view had no content before update
+    state.scrollToTopWhenFinished = ![self pb_hasContent];
+    
     // Animate content insets
     [self pb_setScrollViewContentInset:contentInset animated:YES completion:^(BOOL finished) {
         if(finished) {
-            [self pb_scrollToInfiniteIndicatorIfNeeded:YES];
+            [self pb_scrollToInfiniteIndicatorIfNeeded:YES force:forceScroll];
         }
     }];
 
@@ -499,7 +552,11 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
         // Initiate scroll to the bottom if due to user interaction contentOffset.y
         // stuck somewhere between last cell and activity indicator
         if(finished) {
-            [self pb_scrollToInfiniteIndicatorIfNeeded:NO];
+            if(state.scrollToTopWhenFinished) {
+                [self pb_scrollToTop];
+            } else {
+                [self pb_scrollToInfiniteIndicatorIfNeeded:NO force:NO];
+            }
         }
         
         // Curtain is closing they're throwing roses at my feet
@@ -549,44 +606,33 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     // apply trigger offset adjustment
     actionOffset.y -= state.triggerOffset;
     
-    // Disable infinite scroll when scroll view is empty
-    // Default UITableView reports height = 1 on empty tables
-    BOOL hasActualContent = (self.contentSize.height > 1);
-    
-    // is there any content?
-    if(!hasActualContent) {
-        return;
-    }
-    
     // is user initiated?
     if(![self isDragging]) {
         return;
     }
     
-    // did it kick in already?
-    if(state.loading) {
-        return;
-    }
-    
     if(contentOffset.y > actionOffset.y) {
-        TRACE(@"Action.");
-        
-        // Only show the infinite scroll if it is allowed
-        if([self pb_shouldShowInfiniteScroll]) {
-            [self pb_startAnimatingInfiniteScroll];
-            
-            // This will delay handler execution until scroll deceleration
-            [self performSelector:@selector(pb_callInfiniteScrollHandler) withObject:self afterDelay:0.1 inModes:@[ NSDefaultRunLoopMode ]];
-        }
+        [self pb_beginInfinitScrollIfNeeded:NO];
     }
+}
+
+/**
+ *  Scrolls view to top
+ */
+- (void)pb_scrollToTop {
+    CGPoint pt = CGPointZero;
+    pt.y = self.contentInset.top * -1;
+    
+    [self setContentOffset:pt animated:YES];
 }
 
 /**
  *  Scrolls down to activity indicator if it is partially visible
  *
  *  @param reveal scroll to reveal or hide activity indicator
+ *  @param force forces scroll to bottom
  */
-- (void)pb_scrollToInfiniteIndicatorIfNeeded:(BOOL)reveal {
+- (void)pb_scrollToInfiniteIndicatorIfNeeded:(BOOL)reveal force:(BOOL)force {
     // do not interfere with user
     if([self isDragging]) {
         return;
@@ -599,6 +645,11 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
         return;
     }
     
+    // Force table view to update content size
+    if([self isKindOfClass:[UITableView class]]) {
+        PBForceUpdateTableViewContentSize((UITableView *)self);
+    }
+    
     CGFloat contentHeight = [self pb_clampContentSizeToFitVisibleBounds:self.contentSize];
     CGFloat indicatorRowHeight = [self pb_infiniteIndicatorRowHeight];
     
@@ -607,8 +658,31 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     
     TRACE(@"minY = %.2f; maxY = %.2f; offsetY = %.2f", minY, maxY, self.contentOffset.y);
     
-    if(self.contentOffset.y > minY && self.contentOffset.y < maxY) {
+    if((self.contentOffset.y > minY && self.contentOffset.y < maxY) || force) {
         TRACE(@"Scroll to infinite indicator. Reveal: %@", reveal ? @"YES" : @"NO");
+        
+        // Use -scrollToRowAtIndexPath: in case of UITableView
+        // Because -setContentOffset: may not work properly when using self-sizing cells
+        if([self isKindOfClass:[UITableView class]]) {
+            UITableView *tableView = (UITableView *)self;
+            NSInteger numSections = [tableView numberOfSections];
+            NSInteger lastSection = numSections - 1;
+            NSInteger numRows = lastSection >= 0 ? [tableView numberOfRowsInSection:lastSection] : 0;
+            NSInteger lastRow = numRows - 1;
+            
+            if(lastSection >= 0 && lastRow >= 0) {
+                NSIndexPath *indexPath = [NSIndexPath indexPathForRow:lastRow inSection:lastSection];
+                UITableViewScrollPosition scrollPos = reveal ? UITableViewScrollPositionTop : UITableViewScrollPositionBottom;
+                
+                [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:scrollPos animated:YES];
+                
+                // explicit return
+                return;
+            }
+            
+            // setContentOffset: works fine for empty table view.
+        }
+        
         [self setContentOffset:CGPointMake(0, reveal ? maxY : minY) animated:YES];
     }
 }


### PR DESCRIPTION
**Changes:**

- Added new method to start infinite scroll programmatically using `beginInfiniteScroll(forceScroll)`. When `forceScroll = true` scroll view scrolls down to reveal indicator view.
- After loading initial data scroll view returns user back to top.
- `beginInfiniteScroll` won't scroll down during user interaction with scroll view, but will silently fire handler block.
- Added infinite scroll interactions on empty scroll views.
- Improved scroll to bottom which should work fine for self-sizing cells in UITableViews.

**Known issues:**

- iOS simulator 10.2 from Version 8.2 beta (8C23) has some issues with content offset, but everything works fine on earlier simulators or device with latest iOS 10.