### PR TITLE
Not scrolling back when new content arrives

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -96,67 +96,30 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)finishInfiniteScroll;
 
+/**
+ * Removes the extra bottom inset 
+ * You must call this method when the scrollable content has been ended.
+ */
+- (void)scrollableContentDidEnd;
+    
 @end
 
-/**
- Convenience interface for UIScrollView+InfiniteScroll category.
+/*
+ Convenience interface to avoid cast from UIScrollView to common subclasses such as UITableView and UICollectionView.
  */
+
 @interface UITableView (InfiniteScrollConvenienceInterface)
 
-/**
- *  Setup infinite scroll handler
- *
- *  @param handler a handler block
- */
 - (void)addInfiniteScrollWithHandler:(void(^)(UITableView *tableView))handler;
-
-/**
- *  Set a handler to be called to check if the infinite scroll should be shown
- *
- *  @param handler a handler block
- */
 - (void)setShouldShowInfiniteScrollHandler:(BOOL(^)(UITableView *tableView))handler;
-
-/**
- *  Finish infinite scroll animations
- *
- *  You must call this method from your infinite scroll handler to finish all
- *  animations properly and reset infinite scroll state
- *
- *  @param handler a completion block handler called when animation finished
- */
 - (void)finishInfiniteScrollWithCompletion:(nullable void(^)(UITableView *tableView))handler;
-
+    
 @end
 
-
-/**
- Convenience interface for UIScrollView+InfiniteScroll category.
- */
 @interface UICollectionView (InfiniteScrollConvenienceInterface)
 
-/**
- *  Setup infinite scroll handler
- *
- *  @param handler a handler block
- */
 - (void)addInfiniteScrollWithHandler:(void(^)(UICollectionView *collectionView))handler;
-
-/**
- *  Set a handler to be called to check if the infinite scroll should be shown
- *
- *  @param handler a handler block
- */
 - (void)setShouldShowInfiniteScrollHandler:(BOOL(^)(UICollectionView *collectionView))handler;
-
-/**
- *  Finish infinite scroll animations
- *
- *  You must call this method from your infinite scroll handler to finish all
- *  animations properly and reset infinite scroll state
- *
- *  @param handler a completion block handler called when animation finished
- */
 - (void)finishInfiniteScrollWithCompletion:(nullable void(^)(UICollectionView *collectionView))handler;
 
 @end

--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -94,6 +94,13 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 @property (nonatomic) CGFloat indicatorInset;
 
 /**
+ * Flag used to allow adding botton inset (because 
+ * it should be added only once)
+ * Default value is YES
+ */
+@property (nonatomic) BOOL addBottomInset;
+    
+/**
  *  Indicator view margin (top and bottom)
  */
 @property (nonatomic) CGFloat indicatorMargin;
@@ -129,6 +136,7 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
 #else
     _indicatorStyle = UIActivityIndicatorViewStyleGray;
 #endif
+    _addBottomInset = YES;
     
     // Default row height (44) minus activity indicator height (22) / 2
     _indicatorMargin = 11;
@@ -209,6 +217,22 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     if(self.pb_infiniteScrollState.loading) {
         [self pb_stopAnimatingInfiniteScrollWithCompletion:handler];
     }
+}
+    
+- (void)scrollableContentDidEnd{
+    UIEdgeInsets contentInset = self.contentInset;
+    _PBInfiniteScrollState *state = self.pb_infiniteScrollState;
+    
+    if (state.addBottomInset == NO){
+        contentInset.bottom -= state.indicatorInset;
+        state.addBottomInset = YES;
+    }
+    
+    [self pb_setScrollViewContentInset:contentInset animated:YES completion:^(BOOL finished) {
+        if(finished) {
+            [self pb_scrollToInfiniteIndicatorIfNeeded:YES force:YES];
+        }
+    }];
 }
 
 #pragma mark - Accessors
@@ -482,7 +506,10 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     UIEdgeInsets contentInset = self.contentInset;
     
     // Make a room to accommodate indicator view
-    contentInset.bottom += indicatorInset;
+    if (state.addBottomInset){
+        contentInset.bottom += indicatorInset;
+        state.addBottomInset = false;
+    }
     
     // We have to pad scroll view when content height is smaller than view bounds.
     // This will guarantee that indicator view appears at the very bottom of scroll view.
@@ -536,13 +563,13 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
     }
     
     // Remove row height inset
-    contentInset.bottom -= state.indicatorInset;
+    //contentInset.bottom -= state.indicatorInset;
     
     // Remove extra inset added to pad infinite scroll
     contentInset.bottom -= state.extraBottomInset;
     
     // Reset indicator view inset
-    state.indicatorInset = 0;
+    //state.indicatorInset = 0;
     
     // Reset extra bottom inset
     state.extraBottomInset = 0;
@@ -716,5 +743,5 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
         }
     }
 }
-
+    
 @end


### PR DESCRIPTION
By default, when new content arrives, the bottomInset resets; so the
scrollView scrolls up a bit and the only notification for new content is
decrease length of scroll bar.
I've changed this so the bottomInset won't reset and there is always a
constant inset at the bottom of table, except when the scrollable
content has been ended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pronebird/uiscrollview-infinitescroll/55)
<!-- Reviewable:end -->
