### PR TITLE
Fixed bug when there was weird animation which shifts offset

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -683,7 +683,7 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
             // setContentOffset: works fine for empty table view.
         }
         
-        [self setContentOffset:CGPointMake(0, reveal ? maxY : minY) animated:YES];
+        [self setContentOffset:CGPointMake(self.contentOffset.x, reveal ? maxY : minY) animated:YES];
     }
 }
 


### PR DESCRIPTION
Fixed bug when there was weird animation which shifts offset (if there was specified different offset then default one). This shifting occurred when user panned scroll/collectionview during "finishInfiniteScroll" or when he partially hid the progress bar before the "finishInfiniteScroll" was called.