### PR TITLE
Fix for bug with activity indicator view being shown when it should not be

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -457,7 +457,17 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
         
         // This will delay handler execution until scroll deceleration
         [self performSelector:@selector(pb_callInfiniteScrollHandler) withObject:self afterDelay:0.1 inModes:@[ NSDefaultRunLoopMode ]];
+    } else {
+        [self pb_hideActivityIndicator];
     }
+}
+
+/**
+ * Hide activity indicator
+ */
+- (void)pb_hideActivityIndicator {
+    UIView *activityIndicator = [self pb_getOrCreateActivityIndicatorView];
+    activityIndicator.hidden = YES;
 }
 
 /**


### PR DESCRIPTION
```
 self.tableView.setShouldShowInfiniteScrollHandler { [weak self] _ -> Bool in
     return false
 }
```
Above code should not show activity indicator view when user scrolls. 

Fixed so if should not show the infinite scroll, hiding the activity indicator.