### PR TITLE
this prevents a duplicate refresh

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -611,7 +611,7 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
         return;
     }
     
-    if(contentOffset.y > actionOffset.y) {
+    if(contentOffset.y > actionOffset.y && [[self panGestureRecognizer] velocityInView: self].y <= 0) {
         [self pb_beginInfinitScrollIfNeeded:NO];
     }
 }


### PR DESCRIPTION
When the first refresh happens and there is no new content, no matter where the user scrolls this would trigger another refresh. This simply checks the direction of the scroll. If the scroll is up, then don't trigger a refresh.