### PR TITLE
Add support for infinite scroll in horizontal scroll views

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.h
+++ b/Classes/UIScrollView+InfiniteScroll.h
@@ -11,10 +11,30 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, ISCScrollDirection) {
+	/**
+	 *  Trigger infinite scroll when the scroll view reaches the bottom.
+	 *  This is the default. It is also the only supported direction for
+	 *  table views.
+	 */
+	ISCScrollDirectionVertical,
+
+	/**
+	 *  Trigger infinite scroll when the scroll view reaches the right edge.
+	 *  This should be used for horizontally scrolling collection views.
+	 */
+	ISCScrollDirectionHorizontal,
+};
+
 /**
  UIScrollView infinite scroll category
  */
 @interface UIScrollView (InfiniteScroll)
+
+/**
+ * The direction that the infinite scroll should work in (default: ISCScrollDirectionVertical).
+ */
+@property (nonatomic) ISCScrollDirection infiniteScrollDirection;
 
 /**
  *  Flag that indicates whether infinite scroll is animating
@@ -40,14 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) UIView *infiniteScrollIndicatorView;
 
 /**
- *  Vertical margin around indicator view (Default: 11)
+ *  The margin from the scroll view content to the indicator view (Default: 11)
  */
 @property (nonatomic) CGFloat infiniteScrollIndicatorMargin;
 
 /**
- *  Set vertical adjustment for scroll coordinate used to determine when to call handler block.
+ *  Set adjustment for scroll coordinate used to determine when to call handler block.
  *  Non-zero value advances the point when handler block is being called 
- *  making it fire by N points earlier before scroll view reaches the bottom.
+ *  making it fire by N points earlier before scroll view reaches the bottom or right edge.
  *  This value is measured in points and must be positive number.
  *  Default: 0.0
  */


### PR DESCRIPTION
Thanks for this small, very useful library!

As requested by #48, this pull request adds support for infinite scroll in horizontal scroll views (read: collection views).

Horizontal infinite scroll is enabled by specifying `infiniteScrollDirection = ISCScrollDirectionHorizontal` on the scroll view (and adjusting the scroll views scrolling direction accordingly). By default the direction is set to `ISCScrollDirectionVertical`.

To implement this behaviour I basically went through the `InfiniteScroll` category top-to-bottom and introduced a branch wherever the code had previously assumed that the scroll view was scrolling vertically. In other words it's a very naive/simple implementation 🙂

We've been using our fork (with the implemented behaviour) for over four months and haven't run into any issues.