### PR TITLE
Handle scrolling when voiceOver is running

### DIFF
--- a/Classes/UIScrollView+InfiniteScroll.m
+++ b/Classes/UIScrollView+InfiniteScroll.m
@@ -674,7 +674,7 @@ static const void *kPBInfiniteScrollStateKey = &kPBInfiniteScrollStateKey;
  */
 - (void)pb_scrollViewDidScroll:(CGPoint)contentOffset {
     // is user initiated?
-    if(![self isDragging]) {
+    if(![self isDragging] && !UIAccessibilityIsVoiceOverRunning()) {
         return;
     }
 


### PR DESCRIPTION
The infinite scroll block was never called when tabbing through a list with VoiceOver because `isDragging` is false during that process. Nevertheless it is a valid user.initiated action in that situation.
 So i added a check for VoiceOver status.